### PR TITLE
feat: Added workflow to automatically add PR labels

### DIFF
--- a/.github/workflows/copy-issue-labels-to-pr.yml
+++ b/.github/workflows/copy-issue-labels-to-pr.yml
@@ -1,0 +1,18 @@
+name: Copy linked issue labels to PR
+on:
+  pull_request_target:
+    types: [opened, edited, review_requested, synchronize, reopened, ready_for_review]
+
+jobs:
+  copy-issue-labels:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: read
+      contents: read
+      pull-requests: write
+    steps:
+      - name: copy-issue-labels
+        uses: michalvankodev/copy-issue-labels@v1.3.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          labels-to-exclude: triage


### PR DESCRIPTION
Fixes #47 
Github action has been added which automatically copies the labels from Linked Issues and assigns the PR with the same labels.
The triage label will be excluded while copying the labels.

I have already tested the workflow on my forked repo.
Test PR: https://github.com/DhruvChadha22/comic-cult/pull/3